### PR TITLE
called has_dialysis_access_dressing_change but called _cdi in database

### DIFF
--- a/controller/genitourinaryInfo.controller.js
+++ b/controller/genitourinaryInfo.controller.js
@@ -94,7 +94,7 @@ const updatePatientGenitourinaryInfo = async (req, res) => {
       return res.status(404).json({
         message: "Unable to find the patient's genitourinary assessment",
       });
-    } else {
+    } else
       await genitourinaryInfo.update({
         id: req.params.id,
         ...req.body,

--- a/models/genitourinaryInfo.model.js
+++ b/models/genitourinaryInfo.model.js
@@ -59,6 +59,7 @@ module.exports = (sequelize) => {
       has_dialysis_access_dressing_change: {
         type: DataTypes.BOOLEAN,
         allowNull: false,
+        field: "has_dialysis_access_dressing_cdi"
       },
       foley_catheter: {
         type: DataTypes.STRING(100),


### PR DESCRIPTION
in the database called had_dialysis_access_dressing_cdi but in the rest of the code called has_dialysis_access_dressing_change. added this to tell Sequelize to read from and write to the has_dialysis_access_dressing_cdi column in the database while letting the code continue to refer to it as has_dialysis_access_dressing_change. hopefully. 